### PR TITLE
RSECon25 Workshop blogpost (with prep guidance)

### DIFF
--- a/_posts/2025-09-10-rsecon25-workshop.md
+++ b/_posts/2025-09-10-rsecon25-workshop.md
@@ -1,0 +1,32 @@
+---
+layout: post
+title: RSECon25 Workshop
+date: 2025-09-10 15:30:00
+author: Robert Chisholm (Chair)
+categories: event, news
+---
+
+On the 10th September we're hosting our first workshop at [RSECon25](https://rsecon25.society-rse.org/) (15:30-17:00 in OC0.04).
+
+
+[This workshop](https://virtual.oxfordabstracts.com/event/75166/submission/12) will invite attendees to contribute to our knowledge-base, whether that's contributing to [optimisation](/optimisations) or [profiler](/profilers) mini-guides, or reviewing the existing ones.
+
+## Pre-requisites
+
+This workshop is appropriate for attendees that know any programming language used by researchers (e.g. Python, R, C/C++, etc), regardless of their expertise. The exercises available will suit attendees from novice (e.g. reviewing the accessibility of existing materials) to expert (e.g. proposing or drafting new guidance) .
+
+## Preparation
+
+This workshop doesn't require any advanced tooling, everything can be completed with your favourite web browser and text editor (and a GitHub account). We'll bring along some paper forms too, for anyone who fancies a break from their laptop.
+
+You may however want to reflect on what you can contribute ahead of the workshop. Take a look at the [existing optimisations](/optimisations), are these applicable to the language you use? Or are there similar performance patterns you've come across in your own work?
+
+If you have some code you could profile during the workshop, bring that along, you can contribute a profiler mini-guide instead, and maybe profiling your own code will highlight a new performance pattern.
+
+Don't worry if you haven't got time to prepare ahead of the workshop, we'll be bringing along a small backlog of known optimisations that we're yet to document, or you can help test and review existing content.
+
+## guidance
+
+*We'll add this detailed guidance for the workshop closer to the event (likely morning of).*
+
+See you there!


### PR DESCRIPTION
RSECon workshop team will be sending this link out to attendees on the 26th August.