### PR TITLE
BugFix: case studies archive was setup wrong

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -52,7 +52,7 @@ jekyll-archives:
     layouts:
       language: optimisations-language-archive
     slug_mode: pretty
-  casestudies:
+  posts:
     enabled: [language]
     permalinks:
       language: '/case-studies/:name/'


### PR DESCRIPTION
This broke optimisations filter pages.