### PR TITLE
Fix link to CONTRIBUTING.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Ideas and feedback can be submitted via the repository's [issue templates](https
 
 New articles can be submitted directly as pull requests. It's worth using an existing guide as a template, these can be found in `_profilers/` and `_optimisations/` respectively.
 
-For the full contribution guidance, including a loose style guide, please refer to [`CONTRIBUTING.md`](.github/CONTRIBUTING.md).
+For the full contribution guidance, including a loose style guide, please refer to [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
 *Something is better than nothing.*
 


### PR DESCRIPTION
I noticed that the link to the `CONTRIBUTING.md` file in the `README` is incorrect.